### PR TITLE
removed Exposure control debug output

### DIFF
--- a/share/dfn_freeture_template.cfg
+++ b/share/dfn_freeture_template.cfg
@@ -120,10 +120,10 @@ SUNRISE_DURATION = 3600
 EXPOSURE_CONTROL_FREQUENCY = 120
 
 # Enable to save final image with auto exposure control.
-EXPOSURE_CONTROL_SAVE_IMAGE = true
+EXPOSURE_CONTROL_SAVE_IMAGE = false
 
 # Enable to save informations in a .txt file about auto exposure control process.
-EXPOSURE_CONTROL_SAVE_INFOS = true
+EXPOSURE_CONTROL_SAVE_INFOS = false
 
 #--------------------------------------------------------------------------------
 #---------------------------- REGULAR CAPTURES ----------------------------------


### PR DESCRIPTION
quick fix by disabling the debug output. actual problem will need to be fixed by using the DataPaths module in ExposureControl.*